### PR TITLE
Feat/r0

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -35,6 +35,6 @@ eigens <- lapply(countries, processEigen)
 names(eigens) <- countries
 
 out_dir <- args[1]
-write_json(populations, file.path(out_dir, 'population.json'), pretty=TRUE, digits=NA)
-write_json(matrices, file.path(out_dir, 'matrices.json'), matrix='columnmajor', pretty=TRUE, digits=NA)
+write_json(populations, file.path(out_dir, 'population.json'), digits=NA)
+write_json(matrices, file.path(out_dir, 'matrices.json'), matrix='columnmajor', digits=NA)
 write_json(eigens, file.path(out_dir, 'eigens.json'), auto_unbox=TRUE, digits=NA)

--- a/R/export.R
+++ b/R/export.R
@@ -24,17 +24,17 @@ names(matrices) <- countries
 
 dur_R <- 2.09
 dur_hosp <- 5
-processBeta <- function(c) {
+processEigen <- function(c) {
   m <- get_mixing_matrix(c)
   p <- get_population(c)$n
   m <- process_contact_matrix_scaled_age(m, p)
-  beta_est_explicit(dur_R, dur_hosp, prob_hosp, m, R0)
+  adjusted_eigen(dur_R, dur_hosp, prob_hosp, m)
 }
 
-betas <- lapply(countries, processBeta)
-names(betas) <- countries
+eigens <- lapply(countries, processEigen)
+names(eigens) <- countries
 
 out_dir <- args[1]
 write_json(populations, file.path(out_dir, 'population.json'), pretty=TRUE, digits=NA)
 write_json(matrices, file.path(out_dir, 'matrices.json'), matrix='columnmajor', pretty=TRUE, digits=NA)
-write_json(betas, file.path(out_dir, 'betas.json'), auto_unbox=TRUE, digits=NA)
+write_json(eigens, file.path(out_dir, 'eigens.json'), auto_unbox=TRUE, digits=NA)

--- a/R/probs.R
+++ b/R/probs.R
@@ -1,4 +1,4 @@
-R0 <- 2
+R0 <- 3
 prob_hosp <- c(
     0.000744192, 0.000634166,0.001171109, 0.002394593, 0.005346437 ,
     0.010289885, 0.016234604, 0.023349169, 0.028944623, 0.038607042 ,
@@ -16,5 +16,3 @@ prob_non_severe_death_treatment <- c(
 prob_non_severe_death_no_treatment <- vapply(prob_non_severe_death_treatment * 2, min, numeric(1), 1)
 prob_severe_death_treatment <- rep(0.5, length(prob_hosp))
 prob_severe_death_no_treatment <- rep(0.95, length(prob_hosp))
-
-

--- a/R/run.R
+++ b/R/run.R
@@ -16,61 +16,64 @@ m <- squire:::process_contact_matrix_scaled_age(m, population)
 dur_R <- 2.09
 dur_hosp <- 5
 beta <- squire::beta_est_explicit(dur_R, dur_hosp, prob_hosp, m, R0)
-
-pars <- list(N_age = length(population),
-             S_0 = population,
-             E1_0 = rep(0, length(population)),
-             E2_0 = rep(0, length(population)),
-             IMild_0 = rep(1, length(population)),
-             ICase1_0 = rep(1, length(population)),
-             ICase2_0 = rep(1, length(population)),
-             IOxGetLive1_0 = rep(0, length(population)),
-             IOxGetLive2_0 = rep(0, length(population)),
-             IOxGetDie1_0 = rep(0, length(population)),
-             IOxGetDie2_0 = rep(0, length(population)),
-             IOxNotGetLive1_0 = rep(0, length(population)),
-             IOxNotGetLive2_0 = rep(0, length(population)),
-             IOxNotGetDie1_0 = rep(0, length(population)),
-             IOxNotGetDie2_0 = rep(0, length(population)),
-             IMVGetLive1_0 = rep(0, length(population)),
-             IMVGetLive2_0 = rep(0, length(population)),
-             IMVGetDie1_0 = rep(0, length(population)),
-             IMVGetDie2_0 = rep(0, length(population)),
-             IMVNotGetLive1_0 = rep(0, length(population)),
-             IMVNotGetLive2_0 = rep(0, length(population)),
-             IMVNotGetDie1_0 = rep(0, length(population)),
-             IMVNotGetDie2_0 = rep(0, length(population)),
-             IRec1_0 = rep(0, length(population)),
-             IRec2_0 = rep(0, length(population)),
-             R_0 = rep(0, length(population)),
-             D_0 = rep(0, length(population)),
-             gamma_E = (2 * 1/4.58),
-             gamma_R = (1/dur_R),
-             gamma_hosp = (2 * 1/dur_hosp),
-             gamma_get_ox_survive = (2 * 1/6),
-             gamma_get_ox_die = (2 * 1/3.5),
-             gamma_not_get_ox_survive = (2 * 1/9),
-             gamma_not_get_ox_die = (0.5 * 2 * 1/9),
-             gamma_get_mv_survive = (2 * 1/5.5),
-             gamma_get_mv_die = (2 * 1/4),
-             gamma_not_get_mv_survive = (2 * 1/12),
-             gamma_not_get_mv_die = (2 * 1/1),
-             gamma_rec = (2 * 1/6),
-             prob_hosp = prob_hosp,
-             prob_severe = prob_severe,
-             prob_non_severe_death_treatment = prob_non_severe_death_treatment,
-             prob_non_severe_death_no_treatment = prob_non_severe_death_no_treatment,
-             prob_severe_death_treatment = prob_severe_death_treatment,
-             prob_severe_death_no_treatment = prob_severe_death_no_treatment,
-             p_dist = rep(1, length(population)),
-             hosp_bed_capacity = 10,
-             ICU_bed_capacity = 10,
-             tt_matrix = c(0, 50, 100),
-             tt_beta = c(0, 50, 200),
-             beta_set = c(beta, beta/2, beta))
-
 mm <- t(t(m) / population)
-pars$mix_mat_set <- aperm(array(c(mm, mm, mm), dim = c(dim(mm), 3)), c(3, 1, 2))
+mix_mat_set <- aperm(array(c(mm), dim = c(dim(mm), 1)), c(3, 1, 2))
+
+pars <- list(
+  N_age = length(population),
+  S_0 = population,
+  E1_0 = rep(0, length(population)),
+  E2_0 = rep(0, length(population)),
+  IMild_0 = rep(1, length(population)),
+  ICase1_0 = rep(1, length(population)),
+  ICase2_0 = rep(1, length(population)),
+  IOxGetLive1_0 = rep(0, length(population)),
+  IOxGetLive2_0 = rep(0, length(population)),
+  IOxGetDie1_0 = rep(0, length(population)),
+  IOxGetDie2_0 = rep(0, length(population)),
+  IOxNotGetLive1_0 = rep(0, length(population)),
+  IOxNotGetLive2_0 = rep(0, length(population)),
+  IOxNotGetDie1_0 = rep(0, length(population)),
+  IOxNotGetDie2_0 = rep(0, length(population)),
+  IMVGetLive1_0 = rep(0, length(population)),
+  IMVGetLive2_0 = rep(0, length(population)),
+  IMVGetDie1_0 = rep(0, length(population)),
+  IMVGetDie2_0 = rep(0, length(population)),
+  IMVNotGetLive1_0 = rep(0, length(population)),
+  IMVNotGetLive2_0 = rep(0, length(population)),
+  IMVNotGetDie1_0 = rep(0, length(population)),
+  IMVNotGetDie2_0 = rep(0, length(population)),
+  IRec1_0 = rep(0, length(population)),
+  IRec2_0 = rep(0, length(population)),
+  R_0 = rep(0, length(population)),
+  D_0 = rep(0, length(population)),
+  gamma_E = (2 * 1/4.58),
+  gamma_R = (1/dur_R),
+  gamma_hosp = (2 * 1/dur_hosp),
+  gamma_get_ox_survive = (2 * 1/6),
+  gamma_get_ox_die = (2 * 1/3.5),
+  gamma_not_get_ox_survive = (2 * 1/9),
+  gamma_not_get_ox_die = (0.5 * 2 * 1/9),
+  gamma_get_mv_survive = (2 * 1/5.5),
+  gamma_get_mv_die = (2 * 1/4),
+  gamma_not_get_mv_survive = (2 * 1/12),
+  gamma_not_get_mv_die = (2 * 1/1),
+  gamma_rec = (2 * 1/6),
+  prob_hosp = prob_hosp,
+  prob_severe = prob_severe,
+  prob_non_severe_death_treatment = prob_non_severe_death_treatment,
+  prob_non_severe_death_no_treatment = prob_non_severe_death_no_treatment,
+  prob_severe_death_treatment = prob_severe_death_treatment,
+  prob_severe_death_no_treatment = prob_severe_death_no_treatment,
+  p_dist = rep(1, length(population)),
+  hosp_bed_capacity = 10000000000,
+  ICU_bed_capacity = 10000000000,
+  tt_matrix = c(0),
+  mix_mat_set = mix_mat_set,
+  tt_beta = c(0, 50, 200),
+  beta_set = c(beta, beta/2, beta)
+)
+
 
 model_path <- file.path(
   system.file('odin', package = 'squire', mustWork = TRUE),
@@ -78,14 +81,11 @@ model_path <- file.path(
 )
 
 x <- odin::odin(model_path)
-pars$hosp_bed_capacity <- 10000000000
-pars$ICU_bed_capacity <- 10000000000
 mod <- x(user = pars, use_dde = TRUE)
 t <- seq(from = 0, to = 249)
 output <- mod$run(t)
 
 write_json(output, file.path(out_dir, 'output.json'), pretty = TRUE, digits=NA)
-
 write_json(
   pars,
   file.path(out_dir, 'pars.json'),

--- a/R/run.R
+++ b/R/run.R
@@ -74,7 +74,6 @@ pars <- list(
   beta_set = c(beta, beta/2, beta)
 )
 
-
 model_path <- file.path(
   system.file('odin', package = 'squire', mustWork = TRUE),
   "explicit_SEIR_deterministic.R"
@@ -85,7 +84,12 @@ mod <- x(user = pars, use_dde = TRUE)
 t <- seq(from = 0, to = 249)
 output <- mod$run(t)
 
-write_json(output, file.path(out_dir, 'output.json'), pretty = TRUE, digits=NA)
+write_json(
+  output,
+  file.path(out_dir, 'output.json'),
+  pretty = TRUE,
+  digits=NA
+)
 write_json(
   pars,
   file.path(out_dir, 'pars.json'),

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ const mm = getMixingMatrix('Nigeria')
 const beta = getBeta('Nigeria')
 let results = runModel(
   getPopulation('Nigeria'),
-  [0, 50, 100],
-  [mm, mm, mm],
+  [0],
+  [mm],
   [0, 50, 200],
   [beta, beta/2, beta],
   10000000000,

--- a/README.md
+++ b/README.md
@@ -59,13 +59,17 @@ getMixingMatrix('Nigeria');
 // Outputs a 17 x 17 nested array
 ```
 
-#### getBeta
+#### estimateBeta
 
-Returns the transmissibility parameter for the country.
+Estimates the transmissibility parameter (beta) for a country, given R0. If an
+array of R0 is given, a corresponding array of beta estimates will be returned.
 
 ```js
-getBeta('Nigeria');
-// returns value for beta
+estimateBeta('Nigeria', 3);
+// returns an estimate for beta in Nigeria given an R0 of 3
+
+estimateBeta('Nigeria', [3, 3*.5, 3*.3, 3*.25]);
+// returns 4 estimates for beta in Nigeria given 4 different R0s
 ```
 
 #### runModel
@@ -104,13 +108,13 @@ You can get some basic model output by running the following example:
 
 ```js
 const mm = getMixingMatrix('Nigeria')
-const beta = getBeta('Nigeria')
+const beta = estimateBeta('Nigeria', [3, 3/2, 3])
 let results = runModel(
   getPopulation('Nigeria'),
   [0],
   [mm],
   [0, 50, 200],
-  [beta, beta/2, beta],
+  beta,
   10000000000,
   10000000000,
   1,

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -2,7 +2,7 @@ import {
   runModel,
   getPopulation,
   getMixingMatrix,
-  getBeta
+  estimateBeta
 } from "../build/squire.js"
 
 import {
@@ -15,13 +15,13 @@ import { flattenNested } from '../src/utils.js'
 import expected from "../data/output.json"
 
 const mm = getMixingMatrix('Nigeria');
-const beta = getBeta('Nigeria');
+const beta = estimateBeta('Nigeria', [3, 3/2, 3]);
 let results = runModel(
   getPopulation('Nigeria'),
   [0, 50, 100],
   [mm, mm, mm],
   [0, 50, 200],
-  [beta, beta/2, beta],
+  beta,
   10000000000,
   10000000000,
   0,

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,22 @@
 import { transpose312, reshape3d, wellFormedArray } from './utils.js'
 import population from '../data/population.json'
 import matrices from '../data/matrices.json'
-import beta from '../data/betas.json'
+import eigens from '../data/eigens.json'
 import pars from '../data/pars.json'
 
 export const getCountries = () => Object.keys(population);
 export const getPopulation = (country) => { return population[country] };
 export const getMixingMatrix = (country) => { return matrices[country] };
-export const getBeta = (country) => { return beta[country] };
+export const estimateBeta = (country, R0) => {
+  const lambda = eigens[country];
+  if (lambda == null) {
+    throw Error("Unknown country");
+  }
+  if (Array.isArray(R0)) {
+    return R0.map(r => { return r / lambda })
+  }
+  return R0 / lambda;
+};
 
 export const runModel = function(
   population,

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -2,7 +2,7 @@ import {
   runModel,
   getPopulation,
   getMixingMatrix,
-  getBeta
+  estimateBeta
 } from "../src/index.js"
 
 import { flattenNested } from '../src/utils.js'
@@ -27,13 +27,13 @@ describe('runModel', function() {
     global.odin = [ model ];
 
     const mm = getMixingMatrix('Nigeria');
-    const beta = getBeta('Nigeria');
+    const beta = estimateBeta('Nigeria', [3, 3/2, 3]);
     runModel(
       getPopulation('Nigeria'),
       [0],
       [mm],
       [0, 50, 200],
-      [beta, beta/2, beta],
+      beta,
       10000000000,
       10000000000,
       0,
@@ -62,7 +62,7 @@ describe('runModel', function() {
 
   it('Survives bad inputs', function() {
     const mm = getMixingMatrix('Nigeria');
-    const beta = getBeta('Nigeria');
+    const beta = estimateBeta('Nigeria', 3);
     const badArguments = [
       [
         getPopulation('Nigeria'),
@@ -124,5 +124,25 @@ describe('runModel', function() {
     badArguments.forEach(args => {
       expect(runModel.bind(...args)).to.throw(Error);
     });
+  });
+});
+
+describe('estimateBeta', function() {
+
+  it('gives expected scalar outputs', function() {
+    expect(estimateBeta('Nigeria', 3)).to.be.closeTo(0.1247291, 1e-6);
+  });
+
+  it('gives expected array outputs', function() {
+    const actual = estimateBeta('Nigeria', [3, 2]);
+    expect(actual[0]).to.be.closeTo(0.1247291, 1e-6);
+    expect(actual[1]).to.be.closeTo(0.08315272, 1e-6);
+  });
+
+  it('errors gracefully when the country cannot be found', function() {
+    expect(estimateBeta.bind('Non existent', 3)).to.throw(
+      Error,
+      'Unknown country'
+    );
   });
 });

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -30,8 +30,8 @@ describe('runModel', function() {
     const beta = getBeta('Nigeria');
     runModel(
       getPopulation('Nigeria'),
-      [0, 50, 100],
-      [mm, mm, mm],
+      [0],
+      [mm],
       [0, 50, 200],
       [beta, beta/2, beta],
       10000000000,
@@ -44,11 +44,18 @@ describe('runModel', function() {
     Object.keys(expected).forEach(key => {
       expect(actual).to.have.property(key);
       const value = actual[key];
+      const expected_value = expected[key];
       if (Array.isArray(value)) {
-        const e_flat = flattenNested(expected[key]);
-        flattenNested(value).forEach((v, i) => {
-          expect(v).to.be.closeTo(e_flat[i], 1e-6);
-        })
+        if (value.length == 1) {
+          expect(value[0]).to.be.closeTo(expected_value, 1e-6);
+        } else {
+          const e_flat = flattenNested(expected[key]);
+          flattenNested(value).forEach((v, i) => {
+            expect(v).to.be.closeTo(e_flat[i], 1e-6);
+          })
+        }
+      } else {
+        expect(value).to.be.closeTo(expected_value, 1e-6);
       }
     })
   });


### PR DESCRIPTION
This change allows clients to parameterise the model from R0

* Replace `getBeta` with `estimateBeta`
* Update `R/export.R` to export eigenvalues

The purpose of this is to allow OJ to upload estimates of R0 via orderly for clients to use.