### PR TITLE
Add documentation and export for eigenvalues

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install squire
         run: |
           R.exe -e "install.packages(c('V8', 'odin', 'deSolve', 'jsonlite', 'remotes'))"
-          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire'))"
+          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.4.8'))"
         shell: pwsh
       - name: Install Chrome
         run: |
@@ -29,7 +29,7 @@ jobs:
         shell: pwsh
       - name: Test bundle
         run: |
-          curl --output chromedriver.zip https://chromedriver.storage.googleapis.com/81.0.4044.69/chromedriver_win32.zip
+          curl --output chromedriver.zip https://chromedriver.storage.googleapis.com/84.0.4147.30/chromedriver_win32.zip
           unzip chromedriver.zip
           npm install
           npm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,12 +25,35 @@ jobs:
         shell: pwsh
       - name: Install Chrome
         run: |
-          $LocalTempDir = $env:TEMP; $ChromeInstaller = "ChromeInstaller.exe"; (new-object    System.Net.WebClient).DownloadFile('http://dl.google.com/chrome/install/375.126/chrome_installer.exe', "$LocalTempDir\$ChromeInstaller"); & "$LocalTempDir\$ChromeInstaller" /silent /install; $Process2Monitor =  "ChromeInstaller"; Do { $ProcessesFound = Get-Process | ?{$Process2Monitor -contains $_.Name} | Select-Object -ExpandProperty Name; If ($ProcessesFound) { "Still running: $($ProcessesFound -join ', ')" | Write-Host; Start-Sleep -Seconds 2 } else { rm "$LocalTempDir\$ChromeInstaller" -ErrorAction SilentlyContinue -Verbose } } Until (!$ProcessesFound)
+          $LocalTempDir = $env:TEMP
+          $ChromeInstaller = "ChromeInstaller.exe"
+          (new-object    System.Net.WebClient).DownloadFile('http://dl.google.com/chrome/install/375.126/chrome_installer.exe', "$LocalTempDir\$ChromeInstaller")
+          & "$LocalTempDir\$ChromeInstaller" /silent /install
+          $Process2Monitor =  "ChromeInstaller"
+          Do {
+            $ProcessesFound = Get-Process | ?{$Process2Monitor -contains $_.Name} | Select-Object -ExpandProperty Name
+            If ($ProcessesFound) {
+              "Still running: $($ProcessesFound -join ', ')" | Write-Host; Start-Sleep -Seconds 2
+            } else {
+              rm "$LocalTempDir\$ChromeInstaller" -ErrorAction SilentlyContinue -Verbose
+            }
+          } Until (!$ProcessesFound)
+        shell: pwsh
+      - name: Install Chromedriver
+        run: |
+          $chromeVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("C:\Program Files (x86)\Google\Chrome\Application\chrome.exe").FileVersion
+          $chromeDriverVersionPrefix = $chromeVersion.split(".")[0..2] -join "."
+          $chromeDriverVersionUrl = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_" + $chromeDriverVersionPrefix
+          $chromeDriverVersion = Invoke-RestMethod -Uri $chromeDriverVersionUrl
+          $chromeDriverZipLink = "https://chromedriver.storage.googleapis.com/" + $chromeDriverVersion + "/chromedriver_win32.zip"
+          Write-Output "Will download $chromeDriverZipLink"
+          $chromeDriverZipFileLocation = "chromedriver_win32.zip"
+          Invoke-WebRequest -Uri $chromeDriverZipLink -OutFile $chromeDriverZipFileLocation
+          Expand-Archive $chromeDriverZipFileLocation -Force
+          Remove-Item -Path $chromeDriverZipFileLocation -Force
         shell: pwsh
       - name: Test bundle
         run: |
-          curl --output chromedriver.zip https://chromedriver.storage.googleapis.com/84.0.4147.30/chromedriver_win32.zip
-          unzip chromedriver.zip
           npm install
           npm run build
           npm run e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.swp
 *.json
+.DS_Store

--- a/R/export.R
+++ b/R/export.R
@@ -11,7 +11,7 @@ names(countries) <- unique(squire::population$iso3c)
 
 out_dir <- args[1]
 for (iso3c in names(countries)) {
-  R0 <- 3;
+  R0 <- 3
   pars <- parameters_explicit_SEEIR(
     countries[[iso3c]],
     hosp_bed_capacity = 1, #dummy value
@@ -23,7 +23,7 @@ for (iso3c in names(countries)) {
     population = pars$population,
     contactMatrix = pars$mix_mat_set,
     beta = pars$beta,
-    eigen = R0 / pars$beta
+    eigenvalue = R0 / pars$beta
   )
 
   write_json(

--- a/R/export.R
+++ b/R/export.R
@@ -11,22 +11,26 @@ names(countries) <- unique(squire::population$iso3c)
 
 out_dir <- args[1]
 for (iso3c in names(countries)) {
+  R0 <- 3;
   pars <- parameters_explicit_SEEIR(
     countries[[iso3c]],
     hosp_bed_capacity = 1, #dummy value
-    ICU_bed_capacity = 1  #dummy value
+    ICU_bed_capacity = 1,  #dummy value
+    R0 = R0
   )
 
   country_data <- list(
     population = pars$population,
     contactMatrix = pars$mix_mat_set,
-    beta = pars$beta
+    beta = pars$beta,
+    eigen = R0 / pars$beta
   )
 
   write_json(
     country_data,
     file.path(out_dir, paste0(iso3c, '.json')),
     matrix='columnmajor',
+    auto_unbox=TRUE,
     digits=NA
   )
 }

--- a/README.md
+++ b/README.md
@@ -97,19 +97,19 @@ Y: A 2D array representing the rows of the table. The first dimension will depen
 The model is parameterised with a country specific `beta` value.
 
 To translate Rt values into beta values, you can divide them by the country
-specific eigen value, e.g:
+specific eigenvalue, e.g:
 
 ```
 import nigeriaData from './data/NGA.json';
 const r0 = 3;
 const rt = [r0, r0/2];
-const beta = rt.map(r => { return r / nigeriaData.eigen });
+const beta = rt.map(r => { return r / nigeriaData.eigenvalue });
 ```
 
-You can translate back to Rt by multiplying by the eigen value:
+You can translate back to Rt by multiplying by the eigenvalue:
 
 ```
 import nigeriaData from './data/NGA.json';
 const beta = [nigeriaData.beta, nigeriaData.beta/2];
-const rt = beta.map(r => { return r * nigeriaData.eigen });
+const rt = beta.map(r => { return r * nigeriaData.eigenvalue });
 ```

--- a/README.md
+++ b/README.md
@@ -91,3 +91,25 @@ Results will be an object representing a table of data. It will have the followi
 Names: The names of the columns of the table. The first name will be t, identifying the time step column. The following names will identify the state and the age group being counted in that column. The age group will be identified in square brackets. E.g. the "S[1]" column represents the count for susceptables in the first age group.
 
 Y: A 2D array representing the rows of the table. The first dimension will depend on the time steps and resolution of the model. The second dimension will be the same size as "Names".
+
+#### beta and Rt
+
+The model is parameterised with a country specific `beta` value.
+
+To translate Rt values into beta values, you can divide them by the country
+specific eigen value, e.g:
+
+```
+import nigeriaData from './data/NGA.json';
+const r0 = 3;
+const rt = [r0, r0/2];
+const beta = rt.map(r => { return r / nigeriaData.eigen });
+```
+
+You can translate back to Rt by multiplying by the eigen value:
+
+```
+import nigeriaData from './data/NGA.json';
+const beta = [nigeriaData.beta, nigeriaData.beta/2];
+const rt = beta.map(r => { return r * nigeriaData.eigen });
+```

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -61,11 +61,11 @@ describe('runModel', function() {
     const r0 = 3;
     const rt = [r0, r0/2];
 
-    rt.map(r => { return r / stlucia.eigen }).forEach((value, i) => {
+    rt.map(r => { return r / stlucia.eigenvalue }).forEach((value, i) => {
       expect(beta[i]).to.be.closeTo(value, 1e-6);
     });
 
-    beta.map(b => { return b * stlucia.eigen }).forEach((value, i) => {
+    beta.map(b => { return b * stlucia.eigenvalue }).forEach((value, i) => {
       expect(rt[i]).to.be.closeTo(value, 1e-6);
     });
   });

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -56,6 +56,20 @@ describe('runModel', function() {
     })
   });
 
+  it('can translate between beta from R0', function() {
+    const beta = [stlucia.beta, stlucia.beta/2];
+    const r0 = 3;
+    const rt = [r0, r0/2];
+
+    rt.map(r => { return r / stlucia.eigen }).forEach((value, i) => {
+      expect(beta[i]).to.be.closeTo(value, 1e-6);
+    });
+
+    beta.map(b => { return b * stlucia.eigen }).forEach((value, i) => {
+      expect(rt[i]).to.be.closeTo(value, 1e-6);
+    });
+  });
+
   it('parameterises beds correctly', function() {
     const expected = pars;
 


### PR DESCRIPTION
Changes:

 * Pinned squire version to 0.4.8
 * Tidied up github workflow to download latest matching version of chromedriver for chrome
 * Export eigenvalues for covidsim
 * Add documentation for converting between "beta" and "Rt" values