### PR TITLE
Changes for new parameterisation in v0.5.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install squire
         run: |
           R.exe -e "install.packages(c('V8', 'odin', 'deSolve', 'jsonlite', 'remotes'))"
-          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.4.8'))"
+          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.5.2'))"
         shell: pwsh
       - name: Install Chrome
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install squire
         run: |
           R.exe -e "install.packages(c('V8', 'odin', 'deSolve', 'jsonlite', 'remotes'))"
-          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.5.2'))"
+          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.5.3'))"
         shell: pwsh
       - name: Install Chrome
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: '3.6.3'
-      - name: Install squire
-        run: |
-          R.exe -e "install.packages(c('V8', 'odin', 'deSolve', 'jsonlite', 'remotes'))"
-          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.5.3'))"
       - name: Run tests
         run: docker run --rm -v "$GITHUB_WORKSPACE":/opt -w /opt mrcide/squire bash -c "npm install && npm run build && npm run test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+      - name: Install squire
+        run: |
+          R.exe -e "install.packages(c('V8', 'odin', 'deSolve', 'jsonlite', 'remotes'))"
+          R.exe -e "remotes::install_github(c('mrc-ide/odin.js', 'mrc-ide/squire@v0.5.3'))"
       - name: Run tests
         run: docker run --rm -v "$GITHUB_WORKSPACE":/opt -w /opt mrcide/squire bash -c "npm install && npm run build && npm run test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: '3.6.3'
       - name: Install squire
         run: |
           R.exe -e "install.packages(c('V8', 'odin', 'deSolve', 'jsonlite', 'remotes'))"

--- a/R/run.R
+++ b/R/run.R
@@ -13,7 +13,6 @@ beds <- c(100, 100000, 100000000)
 R0s <- c(4, 3, 2, 1)
 
 scenario <- 0
-
 for (country in countries) {
   for (bed in beds) {
     for (R0 in R0s) {
@@ -26,7 +25,8 @@ for (country in countries) {
         R0 = c(R0, R0/2),
         time_period = 365,
         hosp_bed_capacity = bed,
-        ICU_bed_capacity = bed
+        ICU_bed_capacity = bed,
+        day_return = TRUE
       )
 
       write_json(
@@ -36,16 +36,18 @@ for (country in countries) {
         digits=NA
       )
 
+      output$parameters$mod_gen <- NULL
+
       write_json(
         output$parameters,
         file.path(out_dir, paste0('pars_', scenario, '.json')),
         auto_unbox=TRUE,
         matrix='columnmajor',
         pretty=TRUE,
-        digits=NA
+        digits=NA,
+        force=TRUE
       )
       scenario <- scenario + 1
     }
   }
 }
-

--- a/R/run.R
+++ b/R/run.R
@@ -46,13 +46,63 @@ for (country in countries) {
         digits=NA
         )
 
-      output$parameters$mod_gen <- NULL
-      output$parameters$init <- NULL
-      output$parameters$walker_params <- NULL
-      output$parameters$day_return <- NULL
+      pars_needed <- c(
+        "N_age", 
+        "S_0", 
+        "E1_0",
+        "E2_0",
+        "IMild_0",
+        "ICase1_0",
+        "ICase2_0",
+        "IOxGetLive1_0",
+        "IOxGetLive2_0",
+        "IOxGetDie1_0",
+        "IOxGetDie2_0",
+        "IOxNotGetLive1_0",
+        "IOxNotGetLive2_0",
+        "IOxNotGetDie1_0",
+        "IOxNotGetDie2_0",
+        "IMVGetLive1_0",
+        "IMVGetLive2_0",
+        "IMVGetDie1_0",
+        "IMVGetDie2_0",
+        "IMVNotGetLive1_0",
+        "IMVNotGetLive2_0",
+        "IMVNotGetDie1_0",
+        "IMVNotGetDie2_0",
+        "IRec1_0",
+        "IRec2_0",
+        "R_0",
+        "D_0",
+        "gamma_E",
+        "gamma_R",
+        "gamma_hosp",
+        "gamma_get_ox_survive",
+        "gamma_get_ox_die",
+        "gamma_not_get_ox_survive",
+        "gamma_not_get_ox_die",
+        "gamma_get_mv_survive",
+        "gamma_get_mv_die",
+        "gamma_not_get_mv_survive",
+        "gamma_not_get_mv_die",
+        "gamma_rec",
+        "prob_hosp",
+        "prob_severe",
+        "prob_non_severe_death_treatment",
+        "prob_non_severe_death_no_treatment",
+        "prob_severe_death_treatment",
+        "prob_severe_death_no_treatment",
+        "p_dist",
+        "hosp_bed_capacity",
+        "ICU_bed_capacity",
+        "tt_matrix",
+        "mix_mat_set",
+        "tt_beta",
+        "beta_set"
+        )
 
       write_json(
-        output$parameters,
+        output$parameters[names(output$parameters) %in% pars_needed],
         file.path(out_dir, paste0('pars_', scenario, '.json')),
         auto_unbox=TRUE,
         matrix='columnmajor',

--- a/R/run.R
+++ b/R/run.R
@@ -20,13 +20,13 @@ for (country in countries) {
       population <- squire::get_population(country)$n
       m <- squire::get_mixing_matrix(country)
       output <- run_deterministic_SEIR_model(
-        population,
-        m,
-        c(0, 50),
-        c(R0, R0/2),
-        365,
-        bed,
-        bed
+        population = population,
+        contact_matrix_set = m,
+        tt_R0 = c(0, 50),
+        R0 = c(R0, R0/2),
+        time_period = 365,
+        hosp_bed_capacity = bed,
+        ICU_bed_capacity = bed
       )
 
       write_json(

--- a/R/run.R
+++ b/R/run.R
@@ -27,6 +27,7 @@ for (country in countries) {
       # matrix for country
       m <- squire::get_mixing_matrix(country)
 
+      # get the model run
       output <- squire::run_deterministic_SEIR_model(
         population = population$n,
         contact_matrix_set = m,
@@ -46,6 +47,7 @@ for (country in countries) {
         digits=NA
         )
 
+      # exact same pars as used to be exported by squire::run_deterministic_SEIR_model
       pars_needed <- c(
         "N_age", 
         "S_0", 
@@ -93,8 +95,8 @@ for (country in countries) {
         "prob_severe_death_treatment",
         "prob_severe_death_no_treatment",
         "p_dist",
-        "hosp_bed_capacity",
-        "ICU_bed_capacity",
+        "hosp_beds",
+        "ICU_beds",
         "tt_matrix",
         "mix_mat_set",
         "tt_beta",

--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,15 @@
+N_age
+gamma_E
+gamma_not_get_ox_survive
+gamma_not_get_ox_die
+gamma_not_get_mv_survive
+gamma_not_get_mv_die
+gamma_rec
+ICU_bed_capacity
+N_age
+gamma_E
+gamma_not_get_ox_survive
+gamma_not_get_ox_die
+gamma_not_get_mv_survive
+gamma_not_get_mv_die
+gamma_rec

--- a/mynewfile3.txt
+++ b/mynewfile3.txt
@@ -1,0 +1,1 @@
+hosp_bed_capacitydievive

--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,9 +1932,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001045",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001045.tgz",
-      "integrity": "sha512-Y8o2Iz1KPcD6FjySbk1sPpvJqchgxk/iow0DABpGyzA1UeQAuxh63Xh0Enj5/BrsYbXtCN32JmR4ZxQTCQ6E6A==",
+      "version": "1.0.30001157",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz",
+      "integrity": "sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==",
       "dev": true
     },
     "chai": {

--- a/test/test_index.js
+++ b/test/test_index.js
@@ -43,7 +43,8 @@ describe('runModel', function() {
       const expected_value = expected[key];
       if (Array.isArray(value)) {
         if (value.length == 1) {
-          expect(value[0]).to.be.closeTo(expected_value, 1e-6);
+          console.log(key);
+          expect(value[0]).to.be.closeTo(expected_value[0], 1e-6);
         } else {
           const e_flat = flattenNested(expected[key]);
           flattenNested(value).forEach((v, i) => {


### PR DESCRIPTION
Hi @giovannic,

The new parameterisation in v0.5.3 of squire needs to be brought across. This gets bundled into the js model after having been sourced from using `R/run.R` right? However, the argument ordering for `run_deterministic_SEIR_model` has since changed. So changes in the PR are:

1. Updating `R/run.R` with new changes `run_deterministic_SEIR_model`
2. e2e test grabs most recent version of squire. 

---

Nearly got it all working but one test still off, which i'm guessing is an off by one index issue as I think I changed how/when we start sims from (day 0 vs 1 being included etc). But the js here is outside my knowledge so might ask for some help (or might be clearer in the morning). 


```
runModel
    1) processes basic parameters correctly
    ✓ can translate between beta from R0
    ✓ parameterises beds correctly
    ✓ Survives bad inputs

  flattenNested
    ✓ flattenNesteds a 3d array in the correct order


  4 passing (21ms)
  1 failing

  1) runModel
       processes basic parameters correctly:
     AssertionError: expected 12878 to be close to 12877 +/- 0.000001
      at /home/oj/GoogleDrive/AcademicWork/covid/githubs/squire_js/test/test_index.js:50:29
      at Array.forEach (<anonymous>)
      at /home/oj/GoogleDrive/AcademicWork/covid/githubs/squire_js/test/test_index.js:49:32
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (test/test_index.js:40:27)
      at processImmediate (node:internal/timers:462:21)

```