### PR TITLE
Add t subset to reff

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ function reff(
   rt,
   beta,
   population,
-  mixingMatrix
+  mixingMatrix,
+  tSubset = null
 )
 ```
 
@@ -142,5 +143,8 @@ Parameters:
  * population - an array with population counts for each age group (called
    `population` in the country json files)
  * mixingMatrix - a 2D array representing an age scaled mixing matrix (called `contactMatrixScaledAge` in the country json files)
+ * tSubset - an array of timesteps to calculate Reff for
 
-This returns an array of Reff values for the corresponding rt and beta arguments
+This returns an array of Reff values for the output at the timesteps in `tSubset`.
+If `tSubset` is null, it will return Reff values for all the rt and beta values
+given.

--- a/test/test_reff.js
+++ b/test/test_reff.js
@@ -9,8 +9,8 @@ import brazil from '../data/BRA.json';
 import inputs from './assets/BRA_inputs.json';
 
 describe('reff', function() {
-  this.timeout(10000);
-  it('Comparison test for Brazil', function() {
+  it('compares well with R runs for Brazil', function() {
+    this.timeout(10000);
     const Rt = inputs.input_params.map(d => d.Rt);
     const beta = inputs.input_params.map(d => d.beta_set);
     const actual = reff(
@@ -21,5 +21,21 @@ describe('reff', function() {
       brazil.contactMatrixScaledAge
     );
     assert(approxEqualArray(actual, reffOutput, 1e-2));
+  });
+
+  it('can compute reff for every 10 values of t', function() {
+    const Rt = inputs.input_params.map(d => d.Rt);
+    const beta = inputs.input_params.map(d => d.beta_set);
+    const t = [...Array(Rt.length).keys()].filter(i => i % 10 === 0);
+    const expected = reffOutput.filter((_, i) => i % 10 === 0);
+    const actual = reff(
+      reffModelOutput,
+      Rt,
+      beta,
+      brazil.population,
+      brazil.contactMatrixScaledAge,
+      t
+    );
+    assert(approxEqualArray(actual, expected, 1e-2));
   });
 });


### PR DESCRIPTION
Changes:

 * Allows client to specify subset of timepoints to calculate Reff for
 * Correct confusingly named `colMultiply` -> `rowMultiply`
 * mathjs' `range` is a Matrix! So we avoid using `range` for `adjustedEigens` and `tSubset`. That way our return value remains a js array and not a matrix.